### PR TITLE
Check quality before resuming downloads

### DIFF
--- a/nndownload.py
+++ b/nndownload.py
@@ -416,16 +416,22 @@ def download_video(session, filename, template_params):
     video_len = int(dl_stream.headers["content-length"])
 
     if os.path.isfile(filename):
-        current_byte_pos = os.path.getsize(filename)
-        if current_byte_pos < video_len:
-            file_condition = "ab"
-            resume_header = {"Range": "bytes={0}-".format(current_byte_pos)}
-            dl = current_byte_pos
-            output("Resuming previous download.\n", logging.INFO)
+        with open(filename, "rb") as file:
+            current_byte_pos = os.path.getsize(filename)
+            if current_byte_pos < video_len:
+                file_condition = "ab"
+                resume_header = {"Range": "bytes={0}-".format(current_byte_pos - BLOCK_SIZE)}
+                dl = current_byte_pos - BLOCK_SIZE
+                output("Checking file integrity before resuming.\n")
 
-        elif current_byte_pos >= video_len:
-            output("File exists and is complete.\n", logging.INFO)
-            return
+            elif current_byte_pos > video_len:
+                output("Current byte position exceeds the length of the video to be downloaded. This download may be of a different quality than the existing data.\n")
+                return
+
+            # current_byte_pos == video_len
+            else:
+                output("File exists and matches current download length.\n", logging.INFO)
+                return
 
     else:
         file_condition = "wb"
@@ -434,10 +440,31 @@ def download_video(session, filename, template_params):
 
     dl_stream = session.get(template_params["url"], headers=resume_header, stream=True)
     dl_stream.raise_for_status()
+    stream_iterator = dl_stream.iter_content(BLOCK_SIZE)
+
+    if os.path.isfile(filename):
+        new_data = next(stream_iterator)
+        new_data_len = len(new_data)
+
+        existing_byte_pos = os.path.getsize(filename)
+        if current_byte_pos - new_data_len <= 0:
+            output("Byte comparison block exceeds the length of the existing file.\n")
+            return
+
+        with open(filename, "rb") as file:
+            file.seek(current_byte_pos - BLOCK_SIZE)
+            existing_data = file.read()[:new_data_len]
+            if new_data == existing_data:
+                dl += new_data_len
+                output("Resuming at byte position {0}.\n".format(dl))
+            else:
+                output("Byte comparison block does not match. This download may be of a different quality than the existing data.\n")
+                return
 
     with open(filename, file_condition) as file:
+        file.seek(dl)
         start_time = time.time()
-        for block in dl_stream.iter_content(BLOCK_SIZE):
+        for block in stream_iterator:
             dl += len(block)
             file.write(block)
             done = int(25 * dl / video_len)


### PR DESCRIPTION
Fixes #37. Compare existing file data with the current download over a window of bytes. If the window matches, the download resumes at that position. The existing file will be overwritten when the download quality is `auto` if:
   -  The existing file length is less than the reported download length and the byte comparison window does not match **or**
   - The existing file is negligibly small

When the download quality is `low` and the existing file data is of a higher quality, the download will raise a FormatNotAvailableException. 
