### PR TITLE
"softer" json handling when downloading a mylist

### DIFF
--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -513,13 +513,12 @@ def request_mylist(session, mylist_id):
     mylist_json = json.loads(mylist_request.text)
 
     items = mylist_json.get("items", [])
-    total_mylist = len(items)
     if mylist_json.get("status") != "ok":
         raise FormatNotAvailableException("Could not retrieve mylist info; response=" + mylist_request.text)
     else:
         for index, item in enumerate(items):
             try:
-                output("{0}/{1}\n".format(index + 1, total_mylist), logging.INFO)
+                output("{0}/{1}\n".format(index + 1, len(items)), logging.INFO)
                 request_video(session, item["video_id"])
 
             except (FormatNotSupportedException, FormatNotAvailableException, ParameterExtractionException) as error:

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -512,11 +512,12 @@ def request_mylist(session, mylist_id):
     mylist_request.raise_for_status()
     mylist_json = json.loads(mylist_request.text)
 
+    items = mylist_json.get("items", [])
+    total_mylist = len(items)
     if mylist_json.get("status") != "ok":
         raise FormatNotAvailableException("Could not retrieve mylist info; response=" + mylist_request.text)
     else:
-        total_mylist = len(mylist_json["items"])
-        for index, item in enumerate(mylist_json["items"]):
+        for index, item in enumerate(items):
             try:
                 output("{0}/{1}\n".format(index + 1, total_mylist), logging.INFO)
                 request_video(session, item["video_id"])

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -512,10 +512,10 @@ def request_mylist(session, mylist_id):
     mylist_request.raise_for_status()
     mylist_json = json.loads(mylist_request.text)
 
-    total_mylist = len(mylist_json["items"])
-    if mylist_json["status"] != "ok":
-        raise FormatNotAvailableException("Could not retrieve mylist info")
+    if mylist_json.get("status") != "ok":
+        raise FormatNotAvailableException("Could not retrieve mylist info; response=" + mylist_request.text)
     else:
+        total_mylist = len(mylist_json["items"])
         for index, item in enumerate(mylist_json["items"]):
             try:
                 output("{0}/{1}\n".format(index + 1, total_mylist), logging.INFO)


### PR DESCRIPTION
make nndownload throw `FormatNotAvailableException` when `items` is not present in `mylist_json`.

* before:
    ```
    KeyError: 'items'
    ```
* after:
    ```
    __main__.FormatNotAvailableException: Could not retrieve mylist info; response={"status":"ng","status_code":403,"status_message":"need_login"}
    ```