### PR TITLE
Use relative import since it is a module

### DIFF
--- a/nndownload/__init__.py
+++ b/nndownload/__init__.py
@@ -1,4 +1,4 @@
-from nndownload import nndownload
+from . import nndownload
 
 
 def execute(*args):


### PR DESCRIPTION
Module(s) should use relative import.

Otherwise it would only work if the `nndownload` folder is directly in path.

Things like 

```
./main.py
./modules/nndownload
./module/othermodules
```` 
And then 
```python
# main.py 
import nndownload from module

nndownload.execute("https://www.nicovideo.jp/watch/so28966396", "-g")
```
will break if use absolute import.