### PR TITLE
Added a MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
requirements.txt does not automatically get included in the package, instead it must be specified in the manifest file.