### PR TITLE
Use highest quality thumbnail available

### DIFF
--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1487,7 +1487,7 @@ def download_thumbnail(session, filename, template_params):
     filename = replace_extension(filename, "jpg")
 
     # Try to retrieve the large thumbnail
-    get_thumb = session.get(template_params["thumbnail_url"] + ".L")
+    get_thumb = session.get(template_params["thumbnail_url"])
     if get_thumb.status_code == 404:
         get_thumb = session.get(template_params["thumbnail_url"])
         get_thumb.raise_for_status()

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1416,7 +1416,7 @@ def collect_video_parameters(session, template_params, params):
         template_params["uploader_id"] = int(params["owner"]["id"]) if params.get("owner") else None
         template_params["description"] = params["video"]["description"]
 
-        template_params["thumbnail_url"] = ( # choose highest available thumbnail from 720p to 240p
+        template_params["thumbnail_url"] = ( # Use highest quality thumbnail available
             params["video"]["thumbnail"]["ogp"]
             or params["video"]["thumbnail"]["player"]
             or params["video"]["thumbnail"]["largeUrl"]

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1486,11 +1486,8 @@ def download_thumbnail(session, filename, template_params):
 
     filename = replace_extension(filename, "jpg")
 
-    # Try to retrieve the large thumbnail
     get_thumb = session.get(template_params["thumbnail_url"])
-    if get_thumb.status_code == 404:
-        get_thumb = session.get(template_params["thumbnail_url"])
-        get_thumb.raise_for_status()
+    get_thumb.raise_for_status()
 
     with open(filename, "wb") as file:
         for block in get_thumb.iter_content(BLOCK_SIZE):

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1416,8 +1416,12 @@ def collect_video_parameters(session, template_params, params):
         template_params["uploader_id"] = int(params["owner"]["id"]) if params.get("owner") else None
         template_params["description"] = params["video"]["description"]
 
-        template_params["thumbnail_url"] = params["video"]["thumbnail"]["url"]
-        # params["video"]["thumbnail"]["largeUrl"] if available
+        template_params["thumbnail_url"] = ( # choose highest available thumbnail from 720p to 240p
+            params["video"]["thumbnail"]["ogp"]
+            or params["video"]["thumbnail"]["player"]
+            or params["video"]["thumbnail"]["largeUrl"]
+            or params["video"]["thumbnail"]["middleUrl"]
+            or params["video"]["thumbnail"]["url"])
 
         template_params["thread_id"] = int(params["comment"]["threads"][0]["id"])
         template_params["published"] = params["video"]["registeredAt"]


### PR DESCRIPTION
Since niconico API schema changes, we have five available thumbnail URLs that can be used. It doesn't matter if it is a normal video or an HLS encrypted video, also doesn't matter if the user has login or not. 

For example, here is the portion of thumbnails information in `api_data` for sm38140033, from top to bottom are thumbnails from worst to best qualities. 
```
      "thumbnail":{
         "url":"https://nicovideo.cdn.nimg.jp/thumbnails/38140033/38140033.82394287",
         "middleUrl":"https://nicovideo.cdn.nimg.jp/thumbnails/38140033/38140033.82394287.M",
         "largeUrl":"https://nicovideo.cdn.nimg.jp/thumbnails/38140033/38140033.82394287.L",
         "player":"https://img.cdn.nimg.jp/s/nicovideo/thumbnails/38140033/38140033.82394287.original/a960x540l?key=52a190060cf17d8280e439793c5352b2e2458abab080d187750f975bbd2126b5",
         "ogp":"https://img.cdn.nimg.jp/s/nicovideo/thumbnails/38140033/38140033.82394287.original/r1280x720l?key=85e590129f856ca5d37e61562bd4b20a3c9e4bba34c87f8b4ea07404ecc93fbc"
      },
```

Also, if you have time, we can have a new feature `--thumbnial-quality` that can allow users to choose desired thumbnail quality to download. But so far this PR is just for improving the default chosen thumbnail quality from highest to lowest, whichever is available. 