### PR TITLE
Comments file formatting

### DIFF
--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1611,7 +1611,7 @@ def download_comments(session: requests.Session, filename: AnyStr, template_para
 
     output("Downloading comments for {0}...\n".format(template_params["id"]), logging.INFO)
 
-    filename = replace_extension(filename, "xml")
+    filename = replace_extension(filename, "json")
 
     comments_post = COMMENTS_API_POST_DATA.format(template_params["thread_params"], template_params["thread_key"]).replace("\'", "\"").replace(": ", ":").replace(", ", ",")
     session.options(COMMENTS_API, headers=API_HEADERS)

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1623,7 +1623,7 @@ def download_comments(session: requests.Session, filename: AnyStr, template_para
         print(get_comments_request.content)
         comments_json = json.loads(get_comments_request.content.decode("utf-8", errors="ignore"))
     except json.decoder.JSONDecodeError as error:
-        comments_json = json.loads({})
+        comments_json = json.loads("{}")
         log_exception(error)
         traceback.print_exc()
     

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1620,10 +1620,9 @@ def download_comments(session: requests.Session, filename: AnyStr, template_para
 
     # Convert bytes data to json format for adding indent.
     try:
-        print(get_comments_request.content)
         comments_json = json.loads(get_comments_request.content.decode("utf-8", errors="ignore"))
     except json.decoder.JSONDecodeError as error:
-        comments_json = json.loads("{}")
+        comments_json = {}
         log_exception(error)
         traceback.print_exc()
     

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1621,14 +1621,14 @@ def download_comments(session: requests.Session, filename: AnyStr, template_para
     # Convert bytes data to json format for adding indent.
     try:
         comments_json = json.loads(get_comments_request.content.decode("utf-8", errors="ignore"))
+        with open(filename, "w", encoding="utf-8") as file:
+            json.dump(comments_json, file, indent=4, ensure_ascii=False)
     except json.decoder.JSONDecodeError as error:
-        comments_json = {}
         log_exception(error)
         traceback.print_exc()
-    
-    with open(filename, "w") as file:
-        json.dump(comments_json, file, indent=4, ensure_ascii=False)
-
+        output("Failed to parse comment file. Output raw file.\n")
+        with open(filename, "wb") as file:
+            file.write(get_comments_request.content)
     output("Finished downloading comments for {0}.\n".format(template_params["id"]), logging.INFO)
 
 

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1617,8 +1617,18 @@ def download_comments(session: requests.Session, filename: AnyStr, template_para
     session.options(COMMENTS_API, headers=API_HEADERS)
     get_comments_request = session.post(COMMENTS_API, data=comments_post, headers=API_HEADERS)
     get_comments_request.raise_for_status()
-    with open(filename, "wb") as file:
-        file.write(get_comments_request.content)
+
+    # Convert bytes data to json format for adding indent.
+    try:
+        print(get_comments_request.content)
+        comments_json = json.loads(get_comments_request.content.decode("utf-8", errors="ignore"))
+    except json.decoder.JSONDecodeError as error:
+        comments_json = json.loads({})
+        log_exception(error)
+        traceback.print_exc()
+    
+    with open(filename, "w") as file:
+        json.dump(comments_json, file, indent=4, ensure_ascii=False)
 
     output("Finished downloading comments for {0}.\n".format(template_params["id"]), logging.INFO)
 


### PR DESCRIPTION
- Change extension of comment file to .json
-> It is a json file, not an xml file.
- Add indent to comment json
-> Read as json and add indent. I am not confident in error handling.