### PR TITLE
Add support for DMS video delivery

### DIFF
--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1329,6 +1329,9 @@ def download_video_media(session: requests.Session, filename: AnyStr, template_p
 
     # Dwango Media Service (DMS)
     if template_params.get("video_uri") or template_params.get("audio_uri"):
+        if _cmdl_opts.threads:
+            output("Multithreading is only supported for DMC delivery. Video will be downloaded on one thread.")
+
         m3u8_streams = []
         # TODO: Fix clumsy parameters check
         with get_temp_dir() as temp_dir:
@@ -2063,6 +2066,9 @@ def main():
         account_username = _cmdl_opts.username
         account_password = _cmdl_opts.password
         session_cookie = _cmdl_opts.session_cookie
+
+        if _cmdl_opts.threads:
+            output("Multithread downloading (-r/--threads) will be deprecated in a future release as it is not supported for DMS delivery.\n", logging.WARNING)
 
         if _cmdl_opts.netrc:
             if _cmdl_opts.username or _cmdl_opts.password or _cmdl_opts.session_cookie:

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1330,7 +1330,7 @@ def download_video_media(session: requests.Session, filename: AnyStr, template_p
     # Dwango Media Service (DMS)
     if template_params.get("video_uri") or template_params.get("audio_uri"):
         if _cmdl_opts.threads:
-            output("Multithreading is only supported for DMC delivery. Video will be downloaded on one thread.")
+            output("Multithreading is only supported for DMC delivery. Video will be downloaded on one thread.\n", logging.WARNING)
 
         m3u8_streams = []
         # TODO: Fix clumsy parameters check

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1339,7 +1339,6 @@ def download_video_media(session: requests.Session, filename: AnyStr, template_p
             output("Multithreading is only supported for DMC delivery. Video will be downloaded on one thread.\n", logging.WARNING)
 
         m3u8_streams = []
-        # TODO: Fix clumsy parameters check
         with get_temp_dir() as temp_dir:
             for stream_type in ["video_uri", "audio_uri"]:
                 if template_params.get(stream_type):

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1338,7 +1338,8 @@ def download_video_media(session: requests.Session, filename: AnyStr, template_p
 
     # If extension was rewritten, presume the download is complete
     if os.path.exists(filename):
-        raise ExistingDownloadEncounteredQuit("Exiting as an existing video was encountered")
+        output("Video exists and appears to have been completed.\n", logging.INFO)
+        return False
 
     complete_filename = filename
     filename = replace_extension(filename, f"part.{template_params['ext']}")

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -422,6 +422,17 @@ def generic_dl_request(session: requests.Session, uri: AnyStr, filename: AnyStr,
     return request_body
 
 
+def rewrite_file(filename: AnyStr, old_str: AnyStr, new_str: AnyStr):
+    """Replace a string in a text file."""
+
+    with open(filename, "r+") as file:
+        raw = file.read()
+        new = raw.replace(old_str, new_str)
+        file.seek(0)
+        file.write(new)
+        file.truncate()
+
+
 ## Nama methods
 
 def generate_stream(session: requests.Session, master_url: AnyStr) -> AnyStr:
@@ -1231,16 +1242,6 @@ def perform_ffmpeg_dl(filename: AnyStr, streams: List):
     output = ffmpeg.output(*inputs, filename, vcodec="copy", acodec="copy")
     output.run()
 
-
-def rewrite_file(filename: AnyStr, old_str: AnyStr, new_str: AnyStr):
-    """Replace a string in a text file."""
-
-    with open(filename, "r+") as file:
-        raw = file.read()
-        new = raw.replace(old_str, new_str)
-        file.seek(0)
-        file.write(new)
-        file.truncate()
 
 def download_video_media(session: requests.Session, filename: AnyStr, template_params: dict):
     """Download video from response URL and display progress."""

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -2090,9 +2090,6 @@ def main():
         account_password = _cmdl_opts.password
         session_cookie = _cmdl_opts.session_cookie
 
-        if _cmdl_opts.threads:
-            output("Multithread downloading (-r/--threads) will be deprecated in a future release as it is not supported for DMS delivery.\n", logging.WARNING)
-
         if _cmdl_opts.netrc:
             if _cmdl_opts.username or _cmdl_opts.password or _cmdl_opts.session_cookie:
                 output("Ignoring input credentials in favor of .netrc.\n", logging.WARNING)


### PR DESCRIPTION
Will resolve #139. Currently we download the manifests and keys, rewrite them to use the local paths to the keys, and then perform the download using `ffmpeg` as a subprocess. Specifying different qualities is also supported as it was with DMC delivery. Going to get this merged first before we think about adding no audio/video flags for specificying qualities as we'll need to rewrite file extensions. After that we'll think about finally splitting this up by classes because we have a lot of competing mechanisms now.

Resuming partial downloads and multithreading are not supported due to `ffmpeg` limitations, so #148 has been opened to achieve more robust support. As a result, we now write partial or in progress downloads to `.part` files and update to the correct extension when a download is complete. The full extension will be presumed to be a complete download, so this will report incorrectly for any remanining partial downloads out in the wild (and we should really introduce a flag to force overwrites).