### PR TITLE
Implement a native HLS downloader

### DIFF
--- a/nndownload/downloader.py
+++ b/nndownload/downloader.py
@@ -9,6 +9,7 @@ M3U8_KEY_RE = re.compile(r"((?:#EXT-X-KEY)(?:.*),?URI=\")(?P<url>.*)\",IV=0x(?P<
 M3U8_MAP_RE = re.compile(r"((?:#EXT-X-MAP)(?:.*),?URI=\")(?P<url>.*)\"(.*)")
 M3U8_SEGMENT_RE = re.compile(r"(?:#EXTINF):.*\n(.*)")
 
+
 def download_hls(m3u8_url, filename, session, threads=5):
     from .nndownload import FormatNotAvailableException
 
@@ -33,10 +34,10 @@ def download_hls(m3u8_url, filename, session, threads=5):
         f.write(session.get(init_url).content)
 
     def download_segment(segment):
-        r = session.get(segment)
-        r.raise_for_status()
-        cipher = AES.new(key, AES.MODE_CBC, iv=iv)
-        return unpad(cipher.decrypt(r.content), AES.block_size)
+        with session.get(segment) as r:
+            r.raise_for_status()
+            cipher = AES.new(key, AES.MODE_CBC, iv=iv)
+            return unpad(cipher.decrypt(r.content), AES.block_size)
 
     progress = tqdm(total=len(segments), colour="green", unit="seg", desc=f"Downloading {m3u8_type}")
     with ThreadPoolExecutor(max_workers=threads) as executor:

--- a/nndownload/downloader.py
+++ b/nndownload/downloader.py
@@ -13,7 +13,9 @@ M3U8_SEGMENT_RE = re.compile(r"(?:#EXTINF):.*\n(.*)")
 def download_hls(m3u8_url, filename, session, threads=5):
     from .nndownload import FormatNotAvailableException
 
-    m3u8 = session.get(m3u8_url).text
+    with session.get(m3u8_url) as m3u8_request:
+        m3u8_request.raise_for_status()
+        m3u8 = m3u8_request.text
     key_match = M3U8_KEY_RE.search(m3u8)
     init_match = M3U8_MAP_RE.search(m3u8)
     segments = M3U8_SEGMENT_RE.findall(m3u8)
@@ -26,7 +28,9 @@ def download_hls(m3u8_url, filename, session, threads=5):
 
     m3u8_type = 'video' if '/video/' in m3u8 else 'audio'
     key_url = key_match['url']
-    key = session.get(key_url).content
+    with session.get(key_url) as key_request:
+        key_request.raise_for_status()
+        key = key_request.content
     iv = key_match['iv']
     iv = bytes.fromhex(iv)
     init_url = init_match['url']

--- a/nndownload/downloader.py
+++ b/nndownload/downloader.py
@@ -1,0 +1,48 @@
+import re
+from concurrent.futures import ThreadPoolExecutor
+
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
+from tqdm.rich import tqdm
+
+M3U8_KEY_RE = re.compile(r"((?:#EXT-X-KEY)(?:.*),?URI=\")(?P<url>.*)\",IV=0x(?P<iv>.*)")
+M3U8_MAP_RE = re.compile(r"((?:#EXT-X-MAP)(?:.*),?URI=\")(?P<url>.*)\"(.*)")
+M3U8_SEGMENT_RE = re.compile(r"(?:#EXTINF):.*\n(.*)")
+
+def download_hls(m3u8_url, filename, session, threads=5):
+    from .nndownload import FormatNotAvailableException
+
+    m3u8 = session.get(m3u8_url).text
+    key_match = M3U8_KEY_RE.search(m3u8)
+    init_match = M3U8_MAP_RE.search(m3u8)
+    segments = M3U8_SEGMENT_RE.findall(m3u8)
+    if not key_match:
+        raise FormatNotAvailableException("Could not retrieve key file from manifest")
+    if not init_match:
+        raise FormatNotAvailableException("Could not retrieve init file from manifest")
+    if not segments:
+        raise FormatNotAvailableException("Could not retrieve segments from manifest")
+
+    m3u8_type = 'video' if '/video/' in m3u8 else 'audio'
+    key_url = key_match['url']
+    key = session.get(key_url).content
+    iv = key_match['iv']
+    iv = bytes.fromhex(iv)
+    init_url = init_match['url']
+    with open(filename, "wb") as f:
+        f.write(session.get(init_url).content)
+
+    def download_segment(segment):
+        r = session.get(segment)
+        r.raise_for_status()
+        cipher = AES.new(key, AES.MODE_CBC, iv=iv)
+        return unpad(cipher.decrypt(r.content), AES.block_size)
+
+    progress = tqdm(total=len(segments), colour="green", unit="seg", desc=f"Downloading {m3u8_type}")
+    with ThreadPoolExecutor(max_workers=threads) as executor:
+        results = executor.map(download_segment, segments)
+        for decrypted in results:
+            with open(filename, "ab") as f:
+                f.write(decrypted)
+            progress.update()
+    progress.close()

--- a/nndownload/downloader.py
+++ b/nndownload/downloader.py
@@ -26,14 +26,14 @@ def download_hls(m3u8_url, filename, session, threads=5):
     if not segments:
         raise FormatNotAvailableException("Could not retrieve segments from manifest")
 
-    m3u8_type = 'video' if '/video/' in m3u8 else 'audio'
-    key_url = key_match['url']
+    m3u8_type = "video" if "/video/" in m3u8 else "audio"
+    key_url = key_match["url"]
     with session.get(key_url) as key_request:
         key_request.raise_for_status()
         key = key_request.content
-    iv = key_match['iv']
+    iv = key_match["iv"]
     iv = bytes.fromhex(iv)
-    init_url = init_match['url']
+    init_url = init_match["url"]
     with open(filename, "wb") as f:
         f.write(session.get(init_url).content)
 

--- a/nndownload/ffmpeg_dl.py
+++ b/nndownload/ffmpeg_dl.py
@@ -56,7 +56,7 @@ class FfmpegDL:
         )
 
     def convert(self, name: AnyStr, duration: float):
-        progress = tqdm_rich(desc=name, unit="seg", colour="green", total=duration)
+        progress = tqdm_rich(desc=name, unit="sec", colour="green", total=duration)
 
         self.load_subprocess()
 

--- a/nndownload/hls_dl.py
+++ b/nndownload/hls_dl.py
@@ -9,7 +9,9 @@ M3U8_MAP_RE = re.compile(r"((?:#EXT-X-MAP)(?:.*),?URI=\")(?P<url>.*)\"(.*)")
 M3U8_SEGMENT_RE = re.compile(r"(?:#EXTINF):.*\n(.*)")
 
 
-def download_hls(m3u8_url, filename, name, session, progress, threads=5):
+def download_hls(m3u8_url, filename, name, session, progress, threads):
+    """Perform a native HLS download of a provided M3U8 manifest."""
+
     from .nndownload import FormatNotAvailableException
 
     with session.get(m3u8_url) as m3u8_request:
@@ -48,4 +50,3 @@ def download_hls(m3u8_url, filename, name, session, progress, threads=5):
             with open(filename, "ab") as f:
                 f.write(decrypted)
             progress.advance(task_id)
-

--- a/nndownload/hls_dl.py
+++ b/nndownload/hls_dl.py
@@ -11,6 +11,7 @@ M3U8_SEGMENT_RE = re.compile(r"(?:#EXTINF):.*\n(.*)")
 
 def download_hls(m3u8_url, filename, name, session, progress, threads):
     """Perform a native HLS download of a provided M3U8 manifest."""
+    # TODO: Support proxies (#150)
 
     from .nndownload import FormatNotAvailableException
 

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -32,7 +32,7 @@ from rich.progress import Progress
 from urllib3.util import Retry
 
 from .ffmpeg_dl import FfmpegDL, FfmpegDLException
-from .downloader import download_hls
+from .hls_dl import download_hls
 
 __version__ = "1.16.3"
 __author__ = "Alex Aplin"
@@ -1274,7 +1274,7 @@ def perform_native_hls_dl(session: requests.Session, filename: AnyStr, duration:
         with Progress() as progress:
             tasks = []
             for stream, name in m3u8_streams:
-                stream_filename = os.path.join(temp_dir, name + ".ts")
+                stream_filename = replace_extension(os.path.join(temp_dir, name), "ts")
                 thread = threading.Thread(target=download_hls, args=(stream, stream_filename, name, session, progress, threads))
                 thread.start()
                 tasks.append({

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -31,6 +31,7 @@ from requests.utils import add_dict_to_cookiejar
 from urllib3.util import Retry
 
 from .ffmpeg_dl import FfmpegDL, FfmpegDLException
+from .downloader import download_hls
 
 __version__ = "1.16.3"
 __author__ = "Alex Aplin"
@@ -1267,6 +1268,28 @@ def perform_ffmpeg_dl(video_id: AnyStr, filename: AnyStr, duration: float, strea
         raise FormatNotAvailableException("Failed to download video or audio stream")
 
 
+def perform_native_hls_dl(session: requests.Session, filename: AnyStr, duration: float, m3u8_streams: List, threads: int = 1):
+    """Download video and audio streams using native HLS downloader and merge using ffmpeg."""
+
+    for stream, stream_filename in m3u8_streams:
+        download_hls(stream, stream_filename, session=session, threads=threads)
+
+    if len(m3u8_streams) > 1:
+        video_convert = FfmpegDL(streams=[stream_filename for _, stream_filename in m3u8_streams],
+                                 input_kwargs={},
+                                 output_path=filename,
+                                 output_kwargs={
+                                     "vcodec": "copy",
+                                     "acodec": "copy",
+                                 })
+        video_convert.convert(name='Merging audio and video', duration=duration)
+        for _, stream_filename in m3u8_streams:
+            os.remove(stream_filename)
+    else:
+        os.rename(m3u8_streams[0][1], filename)
+    return True
+
+
 def download_video_media(session: requests.Session, filename: AnyStr, template_params: dict):
     """Download video from response URL and display progress."""
 
@@ -1286,29 +1309,17 @@ def download_video_media(session: requests.Session, filename: AnyStr, template_p
         # .part file
         if os.path.exists(filename):
             output("Resuming partial downloads is not supported for videos using DMS delivery. Any partial video data will be overwritten.\n", logging.WARNING)
-        if _cmdl_opts.threads:
-            output("Multithreading is only supported for DMC delivery. Video will be downloaded using one thread.\n", logging.WARNING)
 
         m3u8_streams = []
-        with get_temp_dir() as temp_dir:
-            for stream_type in ["dms_video_uri", "dms_audio_uri"]:
-                if template_params.get(stream_type):
-                    m3u8_path = os.path.join(temp_dir, f"{template_params['id']}_{stream_type}.m3u8")
-                    m3u8 = generic_dl_request(session, template_params[stream_type], m3u8_path)
-                    # It's minimally viable to only rewrite the key file locally for now
-                    # Might be wise to eventually do this with the map and all individual segments
-                    key_match = M3U8_KEY_RE.search(m3u8)
-                    if not key_match:
-                        raise FormatNotAvailableException("Could not retrieve key file from manifest")
-                    key_url = key_match[2]
-                    key_path =  os.path.join(temp_dir, f"{template_params['id']}_{stream_type}.key")
-                    key_path = key_path.replace("\\", "/")
-                    generic_dl_request(session, key_url, key_path, binary=True)
-                    rewrite_file(m3u8_path, key_url, key_path)
-                    m3u8_streams.append(m3u8_path)
-            continue_code = perform_ffmpeg_dl(template_params["id"], filename, float(template_params["duration"]), m3u8_streams)
-            os.rename(filename, complete_filename)
-            return continue_code
+        for stream_type, type_ext in [("dms_video_uri", "vid"), ("dms_audio_uri", "aud")]:
+            if template_params.get(stream_type):
+                stream_filename = filename + "." + type_ext
+                if os.path.exists(filename):
+                    output("Resuming partial downloads is not supported for videos using DMS delivery. Any partial video data will be overwritten.\n", logging.WARNING)
+                m3u8_streams.append((template_params.get(stream_type), stream_filename))
+        continue_code = perform_native_hls_dl(session, filename, float(template_params["duration"]), m3u8_streams, _cmdl_opts.threads)
+        os.rename(filename, complete_filename)
+        return continue_code
 
     # Dwango Media Cluster (DMC)
     dl_stream = session.head(template_params["url"])

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1271,7 +1271,7 @@ def perform_ffmpeg_dl(video_id: AnyStr, filename: AnyStr, duration: float, strea
 
 
 def perform_native_hls_dl(session: requests.Session, filename: AnyStr, duration: float, m3u8_streams: List, threads: int = 1):
-    """Download video and audio streams using native HLS downloader and merge using ffmpeg."""
+    """Download video and audio streams using native HLS downloader and merge using ffmpeg if necessary."""
 
     with get_temp_dir() as temp_dir:
         with Progress() as progress:
@@ -1289,6 +1289,7 @@ def perform_native_hls_dl(session: requests.Session, filename: AnyStr, duration:
             for task in tasks:
                 task["thread"].join()
 
+        # Video and audio
         if len(tasks) > 1:
             stream_filenames = [task["filename"] for task in tasks]
             video_convert = FfmpegDL(streams=stream_filenames,
@@ -1301,6 +1302,7 @@ def perform_native_hls_dl(session: requests.Session, filename: AnyStr, duration:
             video_convert.convert(name='Merging audio and video', duration=duration)
             for stream_filename in stream_filenames:
                 os.remove(stream_filename)
+        # Only audio or video
         else:
             shutil.move(task[0]["filename"], filename)
     return True

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1314,7 +1314,7 @@ def download_video_media(session: requests.Session, filename: AnyStr, template_p
         for stream_type, type_ext in [("dms_video_uri", "vid"), ("dms_audio_uri", "aud")]:
             if template_params.get(stream_type):
                 stream_filename = filename + "." + type_ext
-                if os.path.exists(filename):
+                if os.path.exists(stream_filename):
                     output("Resuming partial downloads is not supported for videos using DMS delivery. Any partial video data will be overwritten.\n", logging.WARNING)
                 m3u8_streams.append((template_params.get(stream_type), stream_filename))
         continue_code = perform_native_hls_dl(session, filename, float(template_params["duration"]), m3u8_streams, _cmdl_opts.threads)

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1271,7 +1271,7 @@ def perform_native_hls_dl(session: requests.Session, filename: AnyStr, duration:
     """Download video and audio streams using native HLS downloader and merge using ffmpeg."""
 
     with get_temp_dir() as temp_dir:
-        with Progress(expand=True) as progress:
+        with Progress() as progress:
             tasks = []
             for stream, name in m3u8_streams:
                 stream_filename = os.path.join(temp_dir, name + ".ts")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ beautifulsoup4
 ffmpeg-python
 gevent
 mutagen
+pycryptodome
 requests
 rich
 setuptools


### PR DESCRIPTION
that supports multi-thread. Merge A/V streams using ffmpeg if needed.

This fixes #148. Afterwards, it should also be trivial to add proxy support (#150), too.