### PR TITLE
Guard for missing params when writing MP4 metadata

### DIFF
--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1937,11 +1937,11 @@ def add_metadata_to_container(filename: AnyStr, template_params: dict):
         container_file = MP4(filename)
         if not container_file.tags:
             container_file.add_tags()
-        if not template_params["title"]:
+        if template_params["title"]:
             container_file["\251nam"] = str(template_params["title"])  # Title
-        if not template_params["uploader"]:
+        if template_params["uploader"]:
             container_file["\251ART"] = str(template_params["uploader"])  # Uploader
-        if not template_params["description"]:
+        if template_params["description"]:
             container_file["desc"] = str(template_params["description"])  # Description
         container_file.save(filename)
     else:

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1937,10 +1937,12 @@ def add_metadata_to_container(filename: AnyStr, template_params: dict):
         container_file = MP4(filename)
         if not container_file.tags:
             container_file.add_tags()
-        container_file["\251nam"] = template_params["title"]  # Title
-        if template_params["uploader"] != None:
-            container_file["\251ART"] = template_params["uploader"]  # Uploader
-        container_file["desc"] = template_params["description"]  # Description
+        if not template_params["title"]:
+            container_file["\251nam"] = str(template_params["title"])  # Title
+        if not template_params["uploader"]:
+            container_file["\251ART"] = str(template_params["uploader"])  # Uploader
+        if not template_params["description"]:
+            container_file["desc"] = str(template_params["description"])  # Description
         container_file.save(filename)
     else:
         output("Container metadata is not supported for this file extension. Skipping...\n", logging.INFO)

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1938,7 +1938,8 @@ def add_metadata_to_container(filename: AnyStr, template_params: dict):
         if not container_file.tags:
             container_file.add_tags()
         container_file["\251nam"] = template_params["title"]  # Title
-        container_file["\251ART"] = template_params["uploader"]  # Uploader
+        if template_params["uploader"] != None:
+            container_file["\251ART"] = template_params["uploader"]  # Uploader
         container_file["desc"] = template_params["description"]  # Description
         container_file.save(filename)
     else:


### PR DESCRIPTION
Fixes #201

Unsure if there is a case where description also returns `None` but will just pr this for now.