### PR TITLE
Update Niconama support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Custom filepaths are constructed like standard Python template strings, e.g. `{u
 ### Using Stream Links
 
 > [!NOTE]
-> This function is currently not working due to site changes. Follow #102 for more information
+> This function is currently not working due to site changes. Follow [#203](https://github.com/AlexAplin/nndownload/issues/203) for more information
 
 After generating a Niconama stream URL, the program must be kept running to keep the stream active. [mpv](https://github.com/mpv-player/mpv) and [streamlink](https://github.com/streamlink/streamlink) are the best options for playing generated stream URLs. Other programs that use aggressive HLS caching and threading may also work.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ nndownload allows you to download videos, images, manga, and process other links
 - When downloading without a login (using -g/--no-login), some videos may not be available for download or may only be available in a lower quality.
 - Running multiple download sessions on the same connection may lead to temporary blocks or throttling.
 - These functions are not currently supported:
-  - Downloading Niconama timeshifts
+  - Watching on-air Niconama streams exteranlly
+  - Downloading Niconama timeshift comments
   - Downloading Seiga comments
   - Downloading channel blog comments
 
@@ -114,18 +115,18 @@ nndownload.execute("-g", "-o", output_path, url)
 
 Custom filepaths are constructed like standard Python template strings, e.g. `{uploader} - {title}.{ext}`. For Seiga manga, the output path should be the template for a chapter directory, e.g. `{manga_id}\{id} - {title}`. The available options are:
 
-- comment_count (videos, images, manga, articles)
-- description (videos, images, manga)
+- comment_count (videos, images, manga, articles, timeshifts)
+- description (videos, images, manga, timeshifts)
 - document_url (videos, images, manga, articles)
-- ext (videos, images, articles)
-- id (videos, images, manga, articles)
-- published (videos, images, manga, articles)
+- ext (videos, images, articles, timeshifts)
+- id (videos, images, manga, articles, timeshifts)
+- published (videos, images, manga, articles, timeshifts)
 - tags (videos, images, manga, articles)
-- title (videos, images, manga, articles)
-- uploader (videos, images, manga, articles)
-- uploader_id (videos, images, manga, articles)
+- title (videos, images, manga, articles, timeshifts)
+- uploader (videos, images, manga, articles, timeshifts)
+- uploader_id (videos, images, manga, articles, timeshifts)
 - url (videos, images)
-- view_count (videos, images, manga)
+- view_count (videos, images, manga, timeshifts)
 - audio_quality (videos)
 - video_quality (videos)
 - article (articles)
@@ -133,21 +134,26 @@ Custom filepaths are constructed like standard Python template strings, e.g. `{u
 - clip_count (images)
 - dms_video_uri (videos)
 - dms_audio_uri (videos)
-- duration (videos)
+- duration (videos, timeshifts)
 - manga_id (manga)
 - manga_title (manga)
 - mylist_count (videos)
 - page_count (manga)
+- provider_type (timeshifts)
 - size_high (videos)
 - size_low (videos)
 - thread_id (videos)
 - thread_key (videos)
 - thread_params (videos)
-- thumbnail_url (videos)
+- thumbnail_url (videos, timeshifts)
+- timeshift_count (timeshifts)
 
 ### Using Stream Links
 
-After generating a stream URL, the program must be kept running to keep the stream active. [mpv](https://github.com/mpv-player/mpv) and [streamlink](https://github.com/streamlink/streamlink) are the best options for playing generated stream URLs. Other programs that use aggressive HLS caching and threading may also work.
+> [!NOTE]
+> This function is currently not working due to site changes. Follow #102 for more information
+
+After generating a Niconama stream URL, the program must be kept running to keep the stream active. [mpv](https://github.com/mpv-player/mpv) and [streamlink](https://github.com/streamlink/streamlink) are the best options for playing generated stream URLs. Other programs that use aggressive HLS caching and threading may also work.
 
 `mpv https://...`
 `streamlink https://... best`

--- a/README_JA.md
+++ b/README_JA.md
@@ -116,18 +116,18 @@ nndownload.execute("-g", "-o", output_path, url)
 ニコニコ静画の場合、出力パスはチャプターディレクトリのテンプレートにする必要があります。例：`{manga_id}\{id} - {title}`  
 利用可能なオプションは以下の通りです。
 
-- comment_count (videos, images, manga, articles)
-- description (videos, images, manga)
+- comment_count (videos, images, manga, articles, timeshifts)
+- description (videos, images, manga, timeshifts)
 - document_url (videos, images, manga, articles)
-- ext (videos, images, articles)
-- id (videos, images, manga, articles)
-- published (videos, images, manga, articles)
+- ext (videos, images, articles, timeshifts)
+- id (videos, images, manga, articles, timeshifts)
+- published (videos, images, manga, articles, timeshifts)
 - tags (videos, images, manga, articles)
-- title (videos, images, manga, articles)
-- uploader (videos, images, manga, articles)
-- uploader_id (videos, images, manga, articles)
+- title (videos, images, manga, articles, timeshifts)
+- uploader (videos, images, manga, articles, timeshifts)
+- uploader_id (videos, images, manga, articles, timeshifts)
 - url (videos, images)
-- view_count (videos, images, manga)
+- view_count (videos, images, manga, timeshifts)
 - audio_quality (videos)
 - video_quality (videos)
 - article (articles)
@@ -135,19 +135,24 @@ nndownload.execute("-g", "-o", output_path, url)
 - clip_count (images)
 - dms_video_uri (videos)
 - dms_audio_uri (videos)
-- duration (videos)
+- duration (videos, timeshifts)
 - manga_id (manga)
 - manga_title (manga)
 - mylist_count (videos)
 - page_count (manga)
+- provider_type (timeshifts)
 - size_high (videos)
 - size_low (videos)
 - thread_id (videos)
 - thread_key (videos)
 - thread_params (videos)
-- thumbnail_url (videos)
+- thumbnail_url (videos, timeshifts)
+- timeshift_count (timeshifts)
 
 ### Using Stream Links
+
+> [!NOTE]
+> This function is currently not working due to site changes. Follow [#203](https://github.com/AlexAplin/nndownload/issues/203) for more information
 
 ストリーム URL の生成後は、ストリームをアクティブな状態に保つためにプログラムを実行し続ける必要があります。生成されたストリーム URL を再生するには、[mpv](https://github.com/mpv-player/mpv)と[streamlink](https://github.com/streamlink/streamlink)が最適なオプションです。ただし、アグレッシブな HLS キャッシングとスレッドを使用する他のプログラムも動作する可能性があります。
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> このREADMEの英語版が最新です。内容の相違点やバグ報告の際は、英語版をご参照ください。
+
 # nndownload
 
 [![PyPI](https://img.shields.io/pypi/v/nndownload.svg)](https://pypi.org/project/nndownload/)

--- a/README_JA.md
+++ b/README_JA.md
@@ -151,9 +151,6 @@ nndownload.execute("-g", "-o", output_path, url)
 
 ### Using Stream Links
 
-> [!NOTE]
-> This function is currently not working due to site changes. Follow [#203](https://github.com/AlexAplin/nndownload/issues/203) for more information
-
 ストリーム URL の生成後は、ストリームをアクティブな状態に保つためにプログラムを実行し続ける必要があります。生成されたストリーム URL を再生するには、[mpv](https://github.com/mpv-player/mpv)と[streamlink](https://github.com/streamlink/streamlink)が最適なオプションです。ただし、アグレッシブな HLS キャッシングとスレッドを使用する他のプログラムも動作する可能性があります。
 
 `mpv https://...`

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> 本 README 的英文版本为最新版本。如有任何差异或提交问题时，请以英文版本为准。
+
 # nndownload
 
 [![PyPI](https://img.shields.io/pypi/v/nndownload.svg)](https://pypi.org/project/nndownload/)

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -145,7 +145,7 @@ NAMA_PERMIT_FRAME = json.loads("""
     "type": "startWatching",
     "data": {
         "stream": {
-            "quality": "super_high",
+            "quality": "{0}",
             "protocol": "hls",
             "latency": "low",
             "accessRightMethod": "single_cookie",
@@ -159,6 +159,10 @@ NAMA_PERMIT_FRAME = json.loads("""
     }
 }
 """)
+
+NAMA_AUDIO_ONLY_QUALITIES = ["audio_high", "audio_only"]
+NAMA_VIDEO_QUALITIES = ["super_high", "high", "normal", "low", "super_low"]
+NAMA_ABR_QUALITY = ["abr"]
 
 NAMA_QUALITY_FRAME = json.loads("""
 {
@@ -467,8 +471,12 @@ async def perform_nama_heartbeat(websocket: aiohttp.ClientWebSocketResponse, wat
 
 async def open_nama_websocket(
         session: requests.Session,
-        uri: AnyStr, event_loop: asyncio.AbstractEventLoop,
-        is_timeshift: tuple = None
+        uri: AnyStr,
+        event_loop: asyncio.AbstractEventLoop,
+        max_quality: AnyStr,
+        template_params: dict,
+        filename: AnyStr = None,
+        is_timeshift: bool = False
 ):
     """Open a WebSocket connection to receive and generate the stream playlist URL."""
 
@@ -476,7 +484,10 @@ async def open_nama_websocket(
     connector = ProxyConnector.from_url(proxy) if proxy else None
     async with aiohttp.ClientSession(connector=connector) as websocket_session:
         async with websocket_session.ws_connect(uri) as websocket:
-            await websocket.send_str(json.dumps(NAMA_PERMIT_FRAME))
+            permit_frame = NAMA_PERMIT_FRAME
+            permit_frame["data"]["quality"] = max_quality
+
+            await websocket.send_str(json.dumps(permit_frame))
             heartbeat = event_loop.create_task(perform_nama_heartbeat(websocket, NAMA_WATCHING_FRAME))
 
             try:
@@ -499,15 +510,26 @@ async def open_nama_websocket(
 
                     if frame_type == "stream":
                         master_url = frame["data"]["uri"]
+                        available_qualities = frame["data"]["availableQualities"]
+                        if _CMDL_OPTS.list_qualities:
+                            list_nama_qualities(available_qualities)
+                            raise ListQualitiesQuit("Exiting after listing available qualities")
+
+                        if _CMDL_OPTS.video_quality:
+                            video_quality = select_nama_quality(template_params, "video_quality", available_qualities, max_quality, _CMDL_OPTS.video_quality)
+                            # TODO: Send NAMA_QUALITY_FRAME
+                        if _CMDL_OPTS.audio_quality:
+                            separate_audio_quality = select_nama_quality(template_params, "audio_quality", available_qualities, None, _CMDL_OPTS.video_quality)
+                            # TODO: Send NAMA_QUALITY_FRAME
 
                         cookie = frame["data"]["cookies"][0]
                         cookie["expires"] = datetime.strptime(cookie["expires"], "%a, %d %b %Y %H:%M:%S %Z").timestamp()
                         session.cookies.set(**cookie)
 
                         if is_timeshift:
-                            template_params, filename = is_timeshift
                             output("Downloading timeshift...\n", logging.WARNING)
 
+                            # TODO: Retrieve audio manifest additionally, if specified
                             m3u8_streams = []
                             manifest_request = session.get(master_url)
                             manifest_request.raise_for_status()
@@ -540,6 +562,62 @@ async def open_nama_websocket(
 
             finally:
                 heartbeat.cancel()
+
+def list_nama_qualities(sources: list):
+    output(f"Qualities:\n")
+    output(f"{'ID':<24} | {'Available':<10} | {'Type':<10}\n", logging.INFO, force=True)
+
+    all_qualities = NAMA_VIDEO_QUALITIES + NAMA_AUDIO_ONLY_QUALITIES + NAMA_ABR_QUALITY
+    for source in all_qualities:
+        is_available = source in sources
+        source_type = "audio" if source in NAMA_AUDIO_ONLY_QUALITIES else "video+audio"
+        output("{:<24} | {:<10} | {:<10}\n".format(source, str(is_available), source_type), logging.INFO, force=True)
+
+
+def select_nama_quality(template_params: dict, template_key: AnyStr, sources: list, max_quality: AnyStr, quality="") -> List[AnyStr]:
+    highest_quality = max_quality if template_key == "video_quality" else NAMA_AUDIO_ONLY_QUALITIES[0]
+    lowest_quality = NAMA_VIDEO_QUALITIES[-1] if template_key == "video_quality" else NAMA_AUDIO_ONLY_QUALITIES[-1]
+    hq_available = highest_quality in sources
+    lq_available = lowest_quality in sources
+
+    if quality and _CMDL_OPTS.force_high_quality:
+        output("-f/--force-high-quality was set. The specified quality will be ignored.\n", logging.WARNING)
+        template_params[template_key] = max_quality
+        return template_params[template_key]
+
+    if quality and _CMDL_OPTS.no_video :
+        output("--no-video or --no-audio was set in addition to a quality. The specified quality will be ignored.\n")
+        template_params[template_key] = max_quality
+        return template_params[template_key]
+
+    # quality = "highest"
+    if not hq_available and (_CMDL_OPTS.force_high_quality or (quality and quality.lower() == "highest")):
+        raise FormatNotAvailableException("Highest quality is not currently available")
+    elif _CMDL_OPTS.force_high_quality or (quality and quality.lower() == "highest"):
+        template_params[template_key] = highest_quality
+        return template_params[template_key]
+
+    # quality = "lowest"
+    if (quality and quality.lower() == "lowest") and lq_available:
+        template_params[template_key] = lowest_quality
+        return template_params[template_key]
+    elif quality and quality.lower() == "lowest":
+        raise FormatNotAvailableException("Lowest quality not available. Please verify that the stream is able to be viewed")
+
+    # Other specified quality
+    if quality:
+        filtered_qualities = NAMA_VIDEO_QUALITIES + NAMA_ABR_QUALITY if template_key == "video_quality" else NAMA_AUDIO_ONLY_QUALITIES
+        if quality not in filtered_qualities:
+            raise FormatNotAvailableException("{1} '{0}' is not available. Available qualities: {2}".format(quality, template_key, filtered_qualities))
+        else:
+            template_params[template_key] = quality
+            return template_params[template_key]
+
+    # Default (return highest available quality, not including ABR)
+    else:
+        filtered_qualities = NAMA_VIDEO_QUALITIES if template_key == "video_quality" else NAMA_AUDIO_ONLY_QUALITIES
+        template_params[template_key] = filtered_qualities[0]
+        return template_params[template_key]
 
 
 def reserve_timeshift(session: requests.Session, nama_id: AnyStr) -> AnyStr:
@@ -585,39 +663,45 @@ def request_nama(session: requests.Session, nama_id: AnyStr):
         websocket_url = params["site"]["relive"]["webSocketUrl"]
         event_loop = asyncio.get_event_loop()
 
+        # Specify the max quality reported with the permit frame
+        # Lesser qualities are received on the response frame and can be specified with NAMA_QUALITY_FRAME
+        max_quality = params["program"]["stream"]["maxQuality"]
+
+        template_params = {}
+        template_params["id"] = params["program"]["nicoliveProgramId"]
+        template_params["title"] = params["program"]["title"]
+
+        template_params["ext"] = "mp4"
+        if _CMDL_OPTS.no_video and not _CMDL_OPTS.no_audio:
+            template_params["ext"] = "m4a"
+        elif _CMDL_OPTS.no_audio and not _CMDL_OPTS.no_video:
+            template_params["ext"] = "m4v"
+
+        template_params["published"] = params["program"]["beginTime"]
+        template_params["duration"] = params["program"]["endTime"] - params["program"]["beginTime"] 
+        template_params["provider_type"] = params["program"]["providerType"]
+        template_params["uploader"] = params["program"]["supplier"]["name"]
+        template_params["uploader_id"] = params["program"]["supplier"]["programProviderId"]
+        template_params["description"] = params["program"]["description"]
+
+        template_params["thumbnail_url"] = (  # Use highest quality thumbnail available
+                params["program"]["screenshot"]["urlSet"]["large"]
+                or params["program"]["screenshot"]["urlSet"]["middle"]
+                or params["program"]["screenshot"]["urlSet"]["small"]
+                or params["program"]["screenshot"]["urlSet"]["micro"])
+
+        template_params["view_count"] = int(params["program"]["statistics"]["watchCount"] or 0)
+        template_params["comment_count"] = int(params["program"]["statistics"]["commentCount"] or 0)
+        template_params["timeshift_count"] = int(params["program"]["statistics"]["timeshiftReservationCount"] or 0)
+
+        filename = create_filename(template_params)
+
         if params["program"]["status"] == "ENDED":
             if (_CMDL_OPTS.no_audio and _CMDL_OPTS.no_video):
                 output("--no-audio and --no-video were both specified. Treating this download as if --skip-media was set.\n", logging.WARNING)
                 _CMDL_OPTS.skip_media = True
-
-            template_params = {}
-            template_params["id"] = params["program"]["nicoliveProgramId"]
-            template_params["title"] = params["program"]["title"]
-
-            template_params["ext"] = "mp4"
-            if not _CMDL_OPTS.no_video and _CMDL_OPTS.no_audio:
-                template_params["ext"] = "m4v"
-            elif not _CMDL_OPTS.no_audio and _CMDL_OPTS.no_video:
-                template_params["ext"] = "m4a"
-
-            template_params["published"] = params["program"]["beginTime"]
-            template_params["duration"] = params["program"]["endTime"] - params["program"]["beginTime"] 
-            template_params["provider_type"] = params["program"]["providerType"]
-            template_params["uploader"] = params["program"]["supplier"]["name"]
-            template_params["uploader_id"] = params["program"]["supplier"]["programProviderId"]
-            template_params["description"] = params["program"]["description"]
-
-            template_params["thumbnail_url"] = (  # Use highest quality thumbnail available
-                    params["program"]["screenshot"]["urlSet"]["large"]
-                    or params["program"]["screenshot"]["urlSet"]["middle"]
-                    or params["program"]["screenshot"]["urlSet"]["small"]
-                    or params["program"]["screenshot"]["urlSet"]["micro"])
-
-            template_params["view_count"] = int(params["program"]["statistics"]["watchCount"] or 0)
-            template_params["comment_count"] = int(params["program"]["statistics"]["commentCount"] or 0)
-            template_params["timeshift_count"] = int(params["program"]["statistics"]["timeshiftReservationCount"] or 0)
-
-            filename = create_filename(template_params)
+            if _CMDL_OPTS.video_quality and _CMDL_OPTS.audio_quality:
+                output("The video stream manifest includes an audio stream. --audio-quality will be ignored.\n", logging.WARNING)
 
             if not _CMDL_OPTS.skip_media:
                 if os.path.exists(filename):
@@ -626,7 +710,7 @@ def request_nama(session: requests.Session, nama_id: AnyStr):
                 if not websocket_url:
                     websocket_url = reserve_timeshift(session, nama_id)
                 event_loop.run_until_complete(
-                    open_nama_websocket(session, websocket_url, event_loop, is_timeshift=(template_params, filename)))
+                    open_nama_websocket(session, websocket_url, event_loop, max_quality, template_params, filename, is_timeshift=True))
 
             if _CMDL_OPTS.dump_metadata:
                 dump_metadata(filename, template_params)
@@ -638,7 +722,7 @@ def request_nama(session: requests.Session, nama_id: AnyStr):
 
         elif params["program"]["status"] == "ON_AIR":
             event_loop.run_until_complete(
-                open_nama_websocket(session, websocket_url, event_loop))
+                open_nama_websocket(session, websocket_url, event_loop, max_quality, template_params, is_timeshift=False))
 
     else:
         raise FormatNotAvailableException("Could not retrieve nama info")
@@ -1568,8 +1652,17 @@ def list_qualities(sources_type: str, sources: list, is_dms: bool):
 def select_quality(template_params: dict, template_key: AnyStr, sources: list, quality="") -> List[AnyStr]:
     """Select the specified quality from a sources list on DMC and DMS videos."""
 
+    bare_sources = [item["id"] for item in sources if item["isAvailable"]]
+
     if quality and _CMDL_OPTS.force_high_quality:
-        output("-f/--force-high-quality was set. Ignoring specified quality...\n", logging.WARNING)
+        output("-f/--force-high-quality was set. The specified quality will be ignored.\n", logging.WARNING)
+        template_params[template_key] = bare_sources[0]
+        return bare_sources
+
+    if quality and _CMDL_OPTS.no_video :
+        output("--no-video or --no-audio was set in addition to a quality. The specified quality will be ignored.\n")
+        template_params[template_key] = bare_sources[0]
+        return bare_sources
 
     # Assumes qualities are in descending order
     highest_quality = sources[0]
@@ -1592,7 +1685,6 @@ def select_quality(template_params: dict, template_key: AnyStr, sources: list, q
         raise FormatNotAvailableException("Lowest quality not available. Please verify that the video is able to be viewed")
 
     # Other specified quality
-    bare_sources = [item["id"] for item in sources if item["isAvailable"]]
     if quality:
         filtered = list(filter(lambda q: q.lower() == quality.lower(), bare_sources))
         if not filtered:
@@ -1658,7 +1750,7 @@ def perform_api_request(session: requests.Session, document: BeautifulSoup) -> d
             # Limited to one video and audio source
             video_source = video_sources[0]
             audio_source = audio_sources[0]
-            payload = json.dumps({"outputs":[[video_source, audio_source]]})
+            payload = json.dumps({"outputs": [[video_source, audio_source]]})
 
             output("Retrieving video manifest...\n", logging.INFO)
             headers = {

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -140,7 +140,6 @@ API_HEADERS = {
 
 NAMA_ORIGIN_HEADER = {"Origin": "https://live2.nicovideo.jp"}
 
-# TODO: Verify access change with on-air namas
 NAMA_PERMIT_FRAME = json.loads("""
 {
     "type": "startWatching",
@@ -469,7 +468,7 @@ async def perform_nama_heartbeat(websocket: aiohttp.ClientWebSocketResponse, wat
 async def open_nama_websocket(
         session: requests.Session,
         uri: AnyStr, event_loop: asyncio.AbstractEventLoop,
-        is_timeshift: dict = None
+        is_timeshift: tuple = None
 ):
     """Open a WebSocket connection to receive and generate the stream playlist URL."""
 

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -682,15 +682,24 @@ def request_nama(session: requests.Session, nama_id: AnyStr):
         template_params["duration"] = params["program"]["endTime"] - params["program"]["beginTime"] 
         template_params["provider_type"] = params["program"]["providerType"]
         template_params["uploader"] = params["program"]["supplier"]["name"]
-        template_params["uploader_id"] = params["program"]["supplier"]["programProviderId"]
+        template_params["uploader_type"] = params["program"]["supplier"]["supplierType"]
+
+        if template_params["uploader_type"] == "channel":
+            template_params["uploader_id"] = params["channel"]["id"]
+            template_params["thumbnail_url"] = (  # Use highest quality thumbnail available
+                params["program"]["thumbnail"]["huge"].get(0)
+                or params["program"]["thumbnail"]["large"]
+                or params["program"]["thumbnail"]["small"]
+            )
+        else:
+            template_params["uploader_id"] = params["program"]["supplier"]["programProviderId"]
+            template_params["thumbnail_url"] = (  # Use highest quality thumbnail available
+                    params["program"]["screenshot"]["urlSet"]["large"]
+                    or params["program"]["screenshot"]["urlSet"]["middle"]
+                    or params["program"]["screenshot"]["urlSet"]["small"]
+                    or params["program"]["screenshot"]["urlSet"]["micro"])
+
         template_params["description"] = params["program"]["description"]
-
-        template_params["thumbnail_url"] = (  # Use highest quality thumbnail available
-                params["program"]["screenshot"]["urlSet"]["large"]
-                or params["program"]["screenshot"]["urlSet"]["middle"]
-                or params["program"]["screenshot"]["urlSet"]["small"]
-                or params["program"]["screenshot"]["urlSet"]["micro"])
-
         template_params["view_count"] = int(params["program"]["statistics"]["watchCount"] or 0)
         template_params["comment_count"] = int(params["program"]["statistics"]["commentCount"] or 0)
         template_params["timeshift_count"] = int(params["program"]["statistics"]["timeshiftReservationCount"] or 0)

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -145,7 +145,7 @@ NAMA_PERMIT_FRAME = json.loads("""
     "type": "startWatching",
     "data": {
         "stream": {
-            "quality": "{0}",
+            "quality": "abr",
             "protocol": "hls",
             "latency": "low",
             "accessRightMethod": "single_cookie",
@@ -485,7 +485,7 @@ async def open_nama_websocket(
     async with aiohttp.ClientSession(connector=connector) as websocket_session:
         async with websocket_session.ws_connect(uri) as websocket:
             permit_frame = NAMA_PERMIT_FRAME
-            permit_frame["data"]["quality"] = max_quality
+            permit_frame["data"]["stream"]["quality"] = max_quality
 
             await websocket.send_str(json.dumps(permit_frame))
             heartbeat = event_loop.create_task(perform_nama_heartbeat(websocket, NAMA_WATCHING_FRAME))

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -570,6 +570,7 @@ def list_nama_qualities(sources: list):
     all_qualities = NAMA_VIDEO_QUALITIES + NAMA_AUDIO_ONLY_QUALITIES + NAMA_ABR_QUALITY
     for source in all_qualities:
         is_available = source in sources
+        # TODO: Ideally specify rough encoding estimates ffor what these represent
         source_type = "audio" if source in NAMA_AUDIO_ONLY_QUALITIES else "video+audio"
         output("{:<24} | {:<10} | {:<10}\n".format(source, str(is_available), source_type), logging.INFO, force=True)
 

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -149,7 +149,7 @@ NAMA_PERMIT_FRAME = json.loads("""
             "quality": "super_high",
             "protocol": "hls",
             "latency": "low",
-            "accessRightMethod": "single_cookie"
+            "accessRightMethod": "single_cookie",
             "chasePlay": false
         },
         "room": {

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -570,7 +570,7 @@ def list_nama_qualities(sources: list):
     all_qualities = NAMA_VIDEO_QUALITIES + NAMA_AUDIO_ONLY_QUALITIES + NAMA_ABR_QUALITY
     for source in all_qualities:
         is_available = source in sources
-        # TODO: Ideally specify rough encoding estimates ffor what these represent
+        # TODO: Ideally specify rough encoding estimates for what these represent
         source_type = "audio" if source in NAMA_AUDIO_ONLY_QUALITIES else "video+audio"
         output("{:<24} | {:<10} | {:<10}\n".format(source, str(is_available), source_type), logging.INFO, force=True)
 

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -1963,9 +1963,12 @@ def add_metadata_to_container(filename: AnyStr, template_params: dict):
         container_file = MP4(filename)
         if not container_file.tags:
             container_file.add_tags()
-        container_file["\251nam"] = str(template_params["title"])  # Title
-        container_file["\251ART"] = str(template_params["uploader"]) # Uploader
-        container_file["desc"] = str(template_params["description"]) # Description
+        if template_params["title"]:
+            container_file["\251nam"] = str(template_params["title"])  # Title
+        if template_params["uploader"]:
+            container_file["\251ART"] = str(template_params["uploader"])  # Uploader
+        if template_params["description"]:
+            container_file["desc"] = str(template_params["description"])  # Description
         container_file.save(filename)
     else:
         output("Container metadata is not supported for this file extension. Skipping...\n", logging.INFO)

--- a/nndownload/nndownload.py
+++ b/nndownload/nndownload.py
@@ -734,7 +734,7 @@ def request_nama(session: requests.Session, nama_id: AnyStr):
     if nama_document.find(id="embedded-data"):
         params = json.loads(nama_document.find(id="embedded-data")["data-props"])
 
-        rejection_errors = params["userProgramWatch"]["rejectedReasons"]
+        rejection_errors = params["userProgramWatch"].get("rejectedReasons")
         if rejection_errors:
             raise ParameterExtractionException(f"Stream not available to user with the following errors given: {rejection_errors}")
 


### PR DESCRIPTION
Resolves #11. This also fixes `get_media_from_manifest` to actually respect the media type.

- `-c` is not supported
- On-air namas still don't work and might be troublesome to support. We'll likely need to pass cookies through on players down to ffmpeg `-headers`. This adds a warning to follow that work in #203 
- Better warnings when -an/-aq or -vn/-vq are specified together