### PR TITLE
`setup.py`: Open README.md with UTF-8 text encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 from distutils.util import convert_path
 
 
-with open("README.md", "r") as description_file:
+with open("README.md", "r", encoding="utf8") as description_file:
     long_description = description_file.read()
 
 with open("requirements.txt", "r") as requirements_file:


### PR DESCRIPTION
`README.md` now contains non-ASCII characters.

With version 1.19.1, `pip install nndownload` may fail on Windows because `setup.py` opens `README.md` without specifying `encoding`, which defaults to text encoding corresponding to Windows default codepage instead of UTF-8:

```
Collecting nndownload
  Using cached nndownload-1.19.1.tar.gz (31 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [23 lines of output]
      Traceback (most recent call last):
        File "venv-nndownload\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "venv-nndownload\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "venv-nndownload\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "AppData\Local\Temp\pip-build-env-pf4zqnwi\overlay\Lib\site-packages\setuptools\build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "AppData\Local\Temp\pip-build-env-pf4zqnwi\overlay\Lib\site-packages\setuptools\build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "AppData\Local\Temp\pip-build-env-pf4zqnwi\overlay\Lib\site-packages\setuptools\build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "AppData\Local\Temp\pip-build-env-pf4zqnwi\overlay\Lib\site-packages\setuptools\build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 7, in <module>
      UnicodeDecodeError: 'gbk' codec can't decode byte 0xad in position 201: illegal multibyte sequence
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

This commit should fix the problem.